### PR TITLE
Rail listener: Prevent users that are not signed in from using the activity feed.

### DIFF
--- a/RailWikiChangeListener/app/controllers/activity_controller.rb
+++ b/RailWikiChangeListener/app/controllers/activity_controller.rb
@@ -1,6 +1,7 @@
 require 'cassandra'
 
 class ActivityController < ApplicationController
+  before_action :authenticate_user!
   @@cluster = Cassandra.cluster
   @@session = @@cluster.connect('wiki_changes')
 
@@ -51,5 +52,9 @@ class ActivityController < ApplicationController
     
     events.sort_by! { |event| event[:timestamp] }
     render json: events
+  end
+
+  def authenticate_user!
+    redirect_to new_user_session_path, notice: 'Please sign in to access this page' unless user_signed_in?
   end
 end

--- a/RailWikiChangeListener/app/views/activity/index.html.erb
+++ b/RailWikiChangeListener/app/views/activity/index.html.erb
@@ -1,4 +1,6 @@
 <meta name="csrf-token" content="<%= csrf_meta_tags %>">
+ <%= javascript_include_tag "controllers/activity", "data-turbo-track": "reload", crossorigin: "anonymous" %>
+
 <div class="activity-page">
   <div class="left-column">
     <h3>Authors</h3>
@@ -7,13 +9,11 @@
       <% @authors.each do |author| %>
         <li>
           <input type="checkbox" id="<%= author.name %>" class="author-checkbox" data-author-id="<%= author.id %>">
-          <%= javascript_include_tag "controllers/activity", "data-turbo-track": "reload", crossorigin: "anonymous" %>
           <label for="author-<%= author.id %>"><%= author.name %></label>
         </li>
       <% end %>
     </ul>
   </div>
-
   <div class="right-column">
     <h3>Activity Feed</h3>
     <ul id="activity-feed">

--- a/RailWikiChangeListener/app/views/pages/home.html.erb
+++ b/RailWikiChangeListener/app/views/pages/home.html.erb
@@ -1,3 +1,4 @@
+<%= csrf_meta_tags %>
 <h1>Pages#home</h1>
 <p>Find me in app/views/pages/home.html.erb</p>
 
@@ -24,7 +25,7 @@
     <%= link_to "Lets see and activity Feed", activity_check_path %>
     </p>
     <p>
-    <%= link_to "Sign Out", destroy_user_session_path, 'data-turbo-method': :delete %>
+    <%= button_to "Logout", destroy_user_session_path, method: :delete, data: { turbo: false } %>
     </p>
 <% else %>
     <h2>Log in</h2>


### PR DESCRIPTION
Simple fix to prevent user who are not signed in from viewing the activity feed (will be redirected to sign in.
Also fixed the sign out button (i.e. made it a button and not a link_to)