### PR TITLE
Issue 2: Docker compose fails when starting up again.

### DIFF
--- a/RailWikiChangeListener/docker-compose.yml
+++ b/RailWikiChangeListener/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     image: rails-wiki-change-listener-app
     container_name: rails_app
     depends_on:
-      - db
-      - scylla
+      scylla:
+        condition: service_healthy
     ports:
       - "3000:3000"
     volumes:

--- a/RailWikiChangeListener/docker-compose.yml
+++ b/RailWikiChangeListener/docker-compose.yml
@@ -53,6 +53,11 @@ services:
     image: scylladb/scylla:latest
     ports:
       - "9042:9042"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,8 @@ services:
       SCYLLA_HOST: scylla
       SCYLLA_PORT: 9042
     depends_on:
-      - rails_db
-      - scylla
-
+      scylla:
+        condition: service_healthy
   rails_db:
     image: postgres:14
     environment:
@@ -30,3 +29,8 @@ services:
     image: scylladb/scylla:latest
     ports:
       - "9042:9042"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
Issue:
When I stopped that docker, and start it again, I get: Cassandra::Errors::IOError: Connection refused - connect(2) for 1722.18.0.2:9042) (Cassandra::Errors::NoHostsAvailable) because ScyllaDB has not started yet. If I go back and start just the rails app again manually from the docker UI after Scylla has initialized then it works fine. 

Solution:
Added a Health check in the docker compose file that the rails app depends on and will not start until it passes.